### PR TITLE
Drop unused db-devel dependency and conditional logic related to it

### DIFF
--- a/rpm.spec
+++ b/rpm.spec
@@ -105,7 +105,7 @@ Summary:	The RPM package management system
 Name:		rpm
 Epoch:		4
 Version:	4.18.0
-Release:	%{?snapver:0.%{snapver}.}1
+Release:	%{?snapver:0.%{snapver}.}2
 Group:		System/Configuration/Packaging
 Url:		http://www.rpm.org/
 Source0:	http://ftp.rpm.org/releases/%{srcdir}/%{name}-%{srcver}.tar.bz2
@@ -249,15 +249,6 @@ BuildRequires:	doxygen
 BuildRequires:	pkgconfig(libelf)
 BuildRequires:	binutils-devel
 BuildRequires:	gettext-devel
-# We don't need to worry about backwards compatibility
-# on arches that didn't get 4.3/5.0 releases -- so
-# db-devel is only needed for x86_64, znver1 and aarch64.
-# Any arches added after the move to sqlite don't need
-# support for reading old bdb rpmdb
-%define oldarches x86_64 znver1 aarch64
-%ifarch %{oldarches}
-BuildRequires:	db-devel >= 18.1
-%endif
 BuildRequires:	pkgconfig(neon)
 BuildRequires:	pkgconfig(popt)
 BuildRequires:	magic-devel
@@ -515,12 +506,7 @@ autoreconf -i -f
 	--sharedstatedir=%{_var}/lib \
 	--with-archive \
 	--with-vendor=%{_real_vendor} \
-%ifarch %{oldarches}
-	--with-external-db \
 	--enable-bdb-ro \
-%else
-	--disable-bdb-ro \
-%endif
 	--with-lua \
 	--without-selinux \
 	--with-cap \


### PR DESCRIPTION
RPM can't even use the BDB library since RPM 4.17 anyway, so this
has just been hanging around for no reason at all.